### PR TITLE
Update cabal file - tested with GHC 9.8.2

### DIFF
--- a/fuzzyfind.cabal
+++ b/fuzzyfind.cabal
@@ -10,7 +10,7 @@ homepage:      http://github.com/runarorama/fuzzyfind/
 bug-reports:   http://github.com/runarorama/fuzzyfind/issues
 copyright:     Copyright (C) 2021 Unison Computing
 build-type:    Simple
-tested-with:   GHC == 8.8.4, GHC == 8.10.4
+tested-with:   GHC == 8.8.4, GHC == 8.10.4, GHC == 9.8.2
 synopsis:      Fuzzy text matching
 description:   A package that provides an API for fuzzy text search in Haskell, using a modified version of the Smith-Waterman algorithm. The search is intended to behave similarly to the excellent fzf tool by Junegunn Choi.
 category:      Text
@@ -26,7 +26,7 @@ source-repository head
 library
   exposed-modules:     Text.FuzzyFind
   other-extensions:    DeriveGeneric, OverloadedLists, ScopedTypeVariables, ViewPatterns
-  build-depends:       base ==4.*, massiv ==0.6.* || ==1.0.*, containers ==0.6.*, text ==1.2.*
+  build-depends:       base ==4.*, massiv ==0.6.* || ==1.0.*, containers ==0.6.*, text ==1.2.* || ==2.*
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -38,8 +38,8 @@ executable bench
   default-language:    Haskell2010
   build-depends:
     base ==4.*,
-    criterion ==1.5.*,
-    deepseq ==1.4.*,
+    criterion >=1.5 || <=1.6,
+    deepseq >=1.4 || <=1.5,
     fuzzyfind
 
 test-suite spec
@@ -50,7 +50,8 @@ test-suite spec
   main-is: Spec.hs
   other-modules: FuzzyFindSpec
   build-depends: base == 4.*
-               , hspec == 2.7.*
+               , hspec >= 2.7 || <= 2.11
                , containers == 0.6.*
                , QuickCheck == 2.*
                , fuzzyfind
+  build-tool-depends: hspec-discover:hspec-discover


### PR DESCRIPTION
Hey @runarorama !

I was trying to compile Unison via Cabal on OpenBSD and noticed that `fuzzyfind` depended on  `text < 1.3`.

```
[__5] rejecting: fuzzyfind-3.0.1 (conflict: text==2.0.2/installed-2.0.2,
fuzzyfind => text>=1.2 && <1.3)
```

I saw there's already an issue #4 a bout that dependency so I went ahead and raised a PR.

I have next to zero knowledge of the "cabal" ways of doing things so feedback is more than welcome!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility Updates**
  - Added support for GHC version 9.8.2.
  - Updated dependencies to support newer versions of `text`, `criterion`, `deepseq`, and `hspec`.

- **Performance and Testing**
  - Enhanced benchmarking and testing capabilities with updated dependency constraints and new tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Testing:

```
 cabal v2-test
Resolving dependencies...
Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - fuzzyfind-3.0.1 (lib) (configuration changed)
 - fuzzyfind-3.0.1 (test:spec) (configuration changed)
Configuring library for fuzzyfind-3.0.1..
Preprocessing library for fuzzyfind-3.0.1..
Building library for fuzzyfind-3.0.1..
Configuring test suite 'spec' for fuzzyfind-3.0.1..
Preprocessing test suite 'spec' for fuzzyfind-3.0.1..
Building test suite 'spec' for fuzzyfind-3.0.1..
Running 1 test suites...
Test suite spec: RUNNING...
Test suite spec: PASS
Test suite logged to:
/home/eduard/fuzzyfind/dist-newstyle/build/aarch64-osx/ghc-9.8.2/fuzzyfind-3.0.1/t/spec/test/fuzzyfind-3.0.1-spec.log
1 of 1 test suites (1 of 1 test cases) passed.
```